### PR TITLE
Feature - Pause toast timeout on hover

### DIFF
--- a/playground/src/toasts.vue
+++ b/playground/src/toasts.vue
@@ -1,5 +1,6 @@
 <template>
   <push-button @click="test">$toast.show('this is a test')</push-button>
+  <push-button @click="noPauseOnHover">{ pauseOnHover: false }</push-button>
   <push-button @click="noTimeout">{ timeout: 0 }</push-button>
   <push-button @click="warn">warning('warning')</push-button>
   <push-button @click="single">single action</push-button>
@@ -13,6 +14,13 @@ import { useToast } from '../../src'
 const $toast = useToast()
 function test() {
   $toast.show('this is a test')
+}
+
+function noPauseOnHover() {
+  $toast.show({
+    message: 'this is a test',
+    pauseOnHover: false
+  })
 }
 function noTimeout() {
   $toast.show({ message: 'this is a test', timeout: 0 })

--- a/src/GlobalToast.vue
+++ b/src/GlobalToast.vue
@@ -1,6 +1,10 @@
 <template>
   <!-- div class="z-40 fixed inset-0 flex flex-col-reverse items-end justify-center px-4 py-6 pointer-events-none sm:p-6 sm:items-end sm:justify-end'"></div> make sure these dont get purged -->
-  <div ref="toastRef">
+  <div
+    ref="toastRef"
+    @mouseenter="isHovering = true"
+    @mouseleave="isHovering = false"
+  >
     <transition
       enter-active-class="transform ease-out duration-300 transition"
       enter-from-class="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
@@ -135,12 +139,18 @@ const props = defineProps({
     required: false,
     default: 2,
   },
+  pauseOnHover: {
+    type: Boolean,
+    required: false,
+    default: true,
+  },
   primary: Object as PropType<ToastAction>,
   secondary: Object as PropType<ToastAction>,
   wide: Boolean,
 })
 const toastRef = ref<HTMLElement|undefined>(undefined)
 const active = ref(false)
+const isHovering = ref(false)
 let interval:undefined|number = undefined
 const timeLeft = ref(0)
 const speed = 100
@@ -160,8 +170,10 @@ onMounted(() => {
 })
 
 function updateTime() {
-  timeLeft.value -= speed
-  if (timeLeft.value === 0) destroy()
+  if (!props.pauseOnHover || !isHovering.value) {
+    timeLeft.value -= speed
+    if (timeLeft.value === 0) destroy()
+  }
 }
 
 function destroy  (instant = false) {

--- a/src/types/toast.d.ts
+++ b/src/types/toast.d.ts
@@ -28,6 +28,7 @@ export interface ToastProps {
   icon?: boolean|string
   /** make your toast wider for mode detailed info */
   wide?: boolean
+  pauseOnHover?: boolean
 }
 
 export interface TailvueToast {


### PR DESCRIPTION
This PR implements the pause on hover functionality to toast.
Is uses the prop `pauseOnHover` which is true by default.
This PR also updates the playground with an example on how to disable this.

https://user-images.githubusercontent.com/1384775/221058946-62358ba3-ac37-4d2f-8219-a8becbbf7865.mp4

Closes #20 
