### PR TITLE
fix: ensure proper type export mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,14 @@
   "module": "./dist/tailvue.es.js",
   "exports": {
     ".": {
-      "import": "./dist/tailvue.es.js",
-      "require": "./dist/tailvue.umd.js"
+      "import": {
+        "default": "./dist/tailvue.es.js",
+        "types": "./src/typings.d.ts"
+      },
+      "require": {
+        "default": "./dist/tailvue.umd.js",
+        "types": "./src/typings.d.ts"
+      }
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/tailvue.es.js",
-        "types": "./src/typings.d.ts"
+        "types": "./src/typings.d.ts",
+        "default": "./dist/tailvue.es.js"
       },
       "require": {
-        "default": "./dist/tailvue.umd.js",
-        "types": "./src/typings.d.ts"
+        "types": "./src/typings.d.ts",
+        "default": "./dist/tailvue.umd.js"
       }
     }
   },


### PR DESCRIPTION
As per the changes that TypeScript has been pushing since the release of TypeScript v5 with module resolutions it is now required to explicitly define types in the export mapping otherwise errors are thrown. This solution won't fully ensure a pass by [arethetypeswrong](https://github.com/arethetypeswrong/arethetypeswrong.github.io) but it will still be better than it is now. To fully match [arethetypeswrong](https://github.com/arethetypeswrong/arethetypeswrong.github.io) tailvue would need to be bundled separately for ESM and CJS on typings level as well. (`index.d.cts` and `index.d.mts`)