### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ $modal.show({
 
 ### NuxtJS v3
 ```bash
-yarn add --dev @tailvue/nuxt
+npx nuxi@latest module add tailvue
 ```
 
 * Add this to your `nuxt.config.ts`
@@ -82,7 +82,7 @@ modules: [
 
 ### Vue3
 ```bash
-yarn add tailvue
+npx nuxi@latest module add tailvue
 ```
 
 ```ts

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ modules: [
 
 ### Vue3
 ```bash
-npx nuxi@latest module add tailvue
+yarn add tailvue
 ```
 
 ```ts


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
